### PR TITLE
Issue 12: Add java 17 github actions workflow

### DIFF
--- a/.github/workflows/java-17.yml
+++ b/.github/workflows/java-17.yml
@@ -1,0 +1,52 @@
+#    Copyright 2023-2023 the original author or authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#
+#
+
+name: Java 17 CI with Maven
+
+on:
+  push:
+    branches: [ main ]
+  # Each pull request is important to us, doesn't matter from which branch.
+  # Furthermore, we do not want to build on just the default GitHub Action
+  # events, we also want to react onto `labeled` events for our extended
+  # build execution
+  pull_request:
+    types: [ labeled, opened, synchronize, reopened ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven
+
+      - name: Build with Maven
+        run: mvn -B verify -P java-17,run-its

--- a/pom.xml
+++ b/pom.xml
@@ -632,6 +632,14 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>java-17</id>
+            <properties>
+                <maven.compiler.source>17</maven.compiler.source>
+                <maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.release>17</maven.compiler.release>
+            </properties>
+        </profile>
     </profiles>
 
     <distributionManagement>


### PR DESCRIPTION
Solves #12

I created a new maven profile to override the maven compiler properties, setting the source, target, and release to java 17.
Using this new profile, I created a new ci workflow just as discussed, activating the java 17 profile to compile & run tests with java 17.

